### PR TITLE
Fix features

### DIFF
--- a/v2_papers/2005/moore_internet.json
+++ b/v2_papers/2005/moore_internet.json
@@ -209,7 +209,7 @@
           },
           {
             "entropy": [
-              "__effective_bandwidth"
+              "__effectiveBandwidth"
             ]
           }
         ],

--- a/v2_papers/2005/moore_internet.json
+++ b/v2_papers/2005/moore_internet.json
@@ -176,7 +176,7 @@
           },
           {
             "apply": [
-              "__RTTSamples",
+              "__rttSamples",
               "forward"
             ]
           },
@@ -293,7 +293,7 @@
           },
           {
             "apply": [
-              "__RTTSamples",
+              "__rttSamples",
               "forward"
             ]
           },

--- a/v2_papers/2007/auld_bayesian.json
+++ b/v2_papers/2007/auld_bayesian.json
@@ -84,45 +84,45 @@
         "bidirectional": true,
         "features": [
           {
-            "basedon": [
+            "apply": [
               "tcpPshTotalCount",
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               "__initialWindow",
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               "__initialWindow",
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "mean": [
                   "_segmentSize"
                 ]
               },
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "median": [
                   "octetTotalCount"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "count": [
                   {
@@ -137,39 +137,39 @@
                   }
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "variance": [
                   "octetTotalCount"
                 ]
               },
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "minimum": [
                   "_segmentSize"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
-              "__RTTSamplestcptrace",
-              "_client_to_server"
+            "apply": [
+              "__rttSamplesTcpTrace",
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               "tcpPshTotalCount",
-              "_client_to_server"
+              "forward"
             ]
           }
         ],
@@ -193,13 +193,13 @@
             ]
           },
           {
-            "basedon": [
+            "apply": [
               "__postLossACK",
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "apply": [
                   "tcpAckTotalCount",
@@ -220,114 +220,114 @@
                   }
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "maximum": [
                   "_interPacketTimeMicroseconds"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "quantile": [
                   "octetTotalCount",
                   0.25
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               "__3rdLargestFFTComponentOfinterPacketTime",
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               "tcpPshTotalCount",
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               "_flowDurationSeconds",
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               "tcpPshTotalCount",
-              "_server_to_client"
+              "backward"
             ]
           },
           "__totalIdleTime",
           {
-            "basedon": [
+            "apply": [
               {
                 "minimum": [
                   "octetTotalCount"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               "tcpAckTotalCount",
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "quantile": [
                   "_interPacketTimeMicroseconds",
                   0.75
                 ]
               },
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "maximum": [
                   "octetTotalCount"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "stdev": [
                   "__fullSizeRTT"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "stdev": [
                   "__fullSizeRTT"
                 ]
               },
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "divide": [
                   {
@@ -338,18 +338,18 @@
                   "_flowDurationSeconds"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "left_shift": [
                   "tcpWindowSize",
                   "tcpWindowScale"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           "__transitionsTransactionBulk",

--- a/v2_papers/2007/liu_network.json
+++ b/v2_papers/2007/liu_network.json
@@ -115,7 +115,7 @@
           {
             "log": [
               {
-                "map": [
+                "apply": [
                   "packetTotalCount",
                   "backward"
                 ]
@@ -125,7 +125,7 @@
           {
             "log": [
               {
-                "map": [
+                "apply": [
                   "transportOctetDeltaCount",
                   "backward"
                 ]
@@ -135,7 +135,7 @@
           {
             "log": [
               {
-                "map": [
+                "apply": [
                   "tcpPshTotalCount",
                   "forward"
                 ]
@@ -145,7 +145,7 @@
           {
             "log": [
               {
-                "map": [
+                "apply": [
                   "tcpPshTotalCount",
                   "backward"
                 ]

--- a/v2_papers/2008/yang_ap2pnetwork.json
+++ b/v2_papers/2008/yang_ap2pnetwork.json
@@ -72,188 +72,188 @@
         "bidirectional": true,
         "features": [
           {
-            "basedon": [
+            "apply": [
               {
                 "minimum": [
                   "octetTotalCount"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "mean": [
                   "octetTotalCount"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "maximum": [
                   "octetTotalCount"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "stdev": [
                   "octetTotalCount"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "minimum": [
                   "octetTotalCount"
                 ]
               },
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "mean": [
                   "octetTotalCount"
                 ]
               },
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "maximum": [
                   "octetTotalCount"
                 ]
               },
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "stdev": [
                   "octetTotalCount"
                 ]
               },
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "minimum": [
                   "_interPacketTimeMicroseconds"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "mean": [
                   "_interPacketTimeMicroseconds"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "maximum": [
                   "_interPacketTimeMicroseconds"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "stdev": [
                   "_interPacketTimeMicroseconds"
                 ]
               },
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "minimum": [
                   "_interPacketTimeMicroseconds"
                 ]
               },
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "mean": [
                   "_interPacketTimeMicroseconds"
                 ]
               },
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "maximum": [
                   "_interPacketTimeMicroseconds"
                 ]
               },
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               {
                 "stdev": [
                   "_interPacketTimeMicroseconds"
                 ]
               },
-              "_server_to_client"
+              "backward"
             ]
           },
           "_flowDurationSeconds",
           {
-            "basedon": [
+            "apply": [
               "packetTotalCount",
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               "packetTotalCount",
-              "_server_to_client"
+              "backward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               "octetTotalCount",
-              "_client_to_server"
+              "forward"
             ]
           },
           {
-            "basedon": [
+            "apply": [
               "octetTotalCount",
-              "_server_to_client"
+              "backward"
             ]
           }
         ],

--- a/v2_papers/2008/zhao_realtime.json
+++ b/v2_papers/2008/zhao_realtime.json
@@ -98,199 +98,115 @@
         "main_goal": "traffic_classification",
         "features": [
           {
-            "add": [
-              {
-                "quantile": [
-                  {
-                    "map": [
-                      "_interPacketTimeMicroseconds",
-                      {
-                        "select": [
-                          true
-                        ]
-                      }
-                    ]
-                  },
-                  0.25
-                ]
-              }
+            "quantile": [
+              "_interPacketTimeMicroseconds",
+              0.25
             ]
           },
           {
-            "add": [
-              {
-                "quantile": [
-                  {
-                    "map": [
-                      "ethernetTotalLength",
-                      {
-                        "select": [
-                          true
-                        ]
-                      }
-                    ]
-                  },
-                  0.25
-                ]
-              }
+            "quantile": [
+              "ethernetTotalLength",
+              0.25
             ]
           },
           {
-            "add": [
-              {
-                "quantile": [
-                  {
-                    "map": [
-                      "ipTotalLength",
-                      {
-                        "select": [
-                          true
-                        ]
-                      }
-                    ]
-                  },
-                  0.25
-                ]
-              }
+            "quantile": [
+              "ipTotalLength",
+              0.25
             ]
           },
           {
-            "add": [
-              {
-                "quantile": [
-                  {
-                    "map": [
-                      "__controlDataLengthPerPacket",
-                      {
-                        "select": [
-                          true
-                        ]
-                      }
-                    ]
-                  },
-                  0.25
-                ]
-              }
+            "quantile": [
+              "__controlDataLengthPerPacket",
+              0.25
             ]
           },
           {
-            "add": [
+            "apply": [
               {
                 "quantile": [
-                  {
-                    "map": [
-                      "_interPacketTimeMicroseconds",
-                      "forward"
-                    ]
-                  },
+                  "_interPacketTimeMicroseconds",
                   0.25
                 ]
-              }
+              },
+              "forward"
             ]
           },
           {
-            "add": [
+            "apply": [
               {
                 "quantile": [
-                  {
-                    "map": [
-                      "ethernetTotalLength",
-                      "forward"
-                    ]
-                  },
+                  "ethernetTotalLength",
                   0.25
                 ]
-              }
+              },
+              "forward"
             ]
           },
           {
-            "add": [
+            "apply": [
               {
                 "quantile": [
-                  {
-                    "map": [
-                      "ipTotalLength",
-                      "forward"
-                    ]
-                  },
+                  "ipTotalLength",
                   0.25
                 ]
-              }
+              },
+              "forward"
             ]
           },
           {
-            "add": [
+            "apply": [
               {
                 "quantile": [
-                  {
-                    "map": [
-                      "__controlDataLengthPerPacket",
-                      "forward"
-                    ]
-                  },
+                  "__controlDataLengthPerPacket",
                   0.25
                 ]
-              }
+              },
+              "forward"
             ]
           },
           {
-            "add": [
+            "apply": [
               {
                 "quantile": [
-                  {
-                    "map": [
-                      "_interPacketTimeMicroseconds",
-                      "backward"
-                    ]
-                  },
+                  "_interPacketTimeMicroseconds",
                   0.25
                 ]
-              }
+              },
+              "backward"
             ]
           },
           {
-            "add": [
+            "apply": [
               {
                 "quantile": [
-                  {
-                    "map": [
-                      "ethernetTotalLength",
-                      "backward"
-                    ]
-                  },
+                  "ethernetTotalLength",
                   0.25
                 ]
-              }
+              },
+              "backward"
             ]
           },
           {
-            "add": [
+            "apply": [
               {
                 "quantile": [
-                  {
-                    "map": [
-                      "ipTotalLength",
-                      "backward"
-                    ]
-                  },
+                  "ipTotalLength",
                   0.25
                 ]
-              }
+              },
+              "backward"
             ]
           },
           {
-            "add": [
+            "apply": [
               {
                 "quantile": [
-                  {
-                    "map": [
-                      "__controlDataLengthPerPacket",
-                      "backward"
-                    ]
-                  },
+                  "__controlDataLengthPerPacket",
                   0.25
                 ]
-              }
+              },
+              "backward"
             ]
           }
         ],

--- a/v2_papers/2008/zhao_realtime.json
+++ b/v2_papers/2008/zhao_realtime.json
@@ -46,8 +46,8 @@
   },
   "preprocessing": {
     "performed_feature_selection": true,
-    "packet_analysis_oriented": true,
-    "flow_analysis_oriented": false,
+    "packet_analysis_oriented": false,
+    "flow_analysis_oriented": true,
     "flow_aggregation_analysis_oriented": false,
     "tools": [],
     "normalization_type": "no",
@@ -91,7 +91,7 @@
         "role": "main"
       }
     ],
-    "packets": [
+    "flows": [
       {
         "selection": "expert_knowledge",
         "role": "main",
@@ -293,10 +293,16 @@
               }
             ]
           }
+        ],
+        "key_features": [
+          "protocolIdentifier",
+          "sourceIPv4Address",
+          "destinationIPv4Address",
+          "sourceTransportPort",
+          "destinationTransportPort"
         ]
       }
     ],
-    "flows": [],
     "flow_aggregations": [],
     "_comment": "The features in the paper are not 100% clear to me, but I think that is what they meant."
   },

--- a/v2_papers/2012/bujlow_amethod.json
+++ b/v2_papers/2012/bujlow_amethod.json
@@ -52,7 +52,7 @@
     "transformations": [],
     "final_data_format": "mixed_vectors",
     "feature_selections": [],
-    "packets": [
+    "flows": [
       {
         "selection": "expert_knowledge",
         "role": "main",
@@ -60,13 +60,13 @@
         "features": [
           "transportOctetDeltaCount",
           {
-            "map": [
+            "apply": [
               "transportOctetDeltaCount",
               "backward"
             ]
           },
           {
-            "map": [
+            "apply": [
               "transportOctetDeltaCount",
               "forward"
             ]
@@ -74,13 +74,13 @@
           {
             "divide": [
               {
-                "map": [
+                "apply": [
                   "transportOctetDeltaCount",
                   "backward"
                 ]
               },
               {
-                "map": [
+                "apply": [
                   "transportOctetDeltaCount",
                   "forward"
                 ]
@@ -90,13 +90,13 @@
           {
             "divide": [
               {
-                "map": [
+                "apply": [
                   "packetTotalCount",
                   "backward"
                 ]
               },
               {
-                "map": [
+                "apply": [
                   "packetTotalCount",
                   "forward"
                 ]
@@ -244,13 +244,13 @@
           },
           {
             "quantile": [
-              0.25,
               {
                 "map": [
                   "_transportPayloadLength",
                   "forward"
                 ]
-              }
+              },
+              0.25
             ]
           },
           {
@@ -265,13 +265,13 @@
           },
           {
             "quantile": [
-              0.75,
               {
                 "map": [
                   "_transportPayloadLength",
                   "forward"
                 ]
-              }
+              },
+              0.75
             ]
           },
           {
@@ -285,61 +285,51 @@
             ]
           },
           {
-            "divide": [
+            "apply": [
               {
-                "count": [
+                "divide": [
                   {
-                    "select": [
+                    "count": [
                       {
-                        "leq": [
+                        "select": [
                           {
-                            "map": [
+                            "leq": [
                               "_transportPayloadLength",
-                              "backward"
+                              50
                             ]
-                          },
-                          50
+                          }
                         ]
                       }
                     ]
-                  }
+                  },
+                  "packetTotalCount"
                 ]
               },
-              {
-                "map": [
-                  "packetTotalCount",
-                  "backward"
-                ]
-              }
+              "backward"
             ]
           },
           {
-            "divide": [
+            "apply": [
               {
-                "count": [
+                "divide": [
                   {
-                    "select": [
+                    "count": [
                       {
-                        "leq": [
+                        "select": [
                           {
-                            "map": [
+                            "leq": [
                               "_transportPayloadLength",
-                              "forward"
+                              50
                             ]
-                          },
-                          50
+                          }
                         ]
                       }
                     ]
-                  }
+                  },
+                  "packetTotalCount"
                 ]
               },
-              {
-                "map": [
-                  "packetTotalCount",
-                  "forward"
-                ]
-              }
+              "forward"
             ]
           },
           {
@@ -362,61 +352,51 @@
             ]
           },
           {
-            "divide": [
+            "apply": [
               {
-                "count": [
+                "divide": [
                   {
-                    "select": [
+                    "count": [
                       {
-                        "geq": [
+                        "select": [
                           {
-                            "map": [
+                            "geq": [
                               "_transportPayloadLength",
-                              "backward"
+                              1300
                             ]
-                          },
-                          1300
+                          }
                         ]
                       }
                     ]
-                  }
+                  },
+                  "packetTotalCount"
                 ]
               },
-              {
-                "map": [
-                  "packetTotalCount",
-                  "backward"
-                ]
-              }
+              "backward"
             ]
           },
           {
-            "divide": [
+            "apply": [
               {
-                "count": [
+                "divide": [
                   {
-                    "select": [
+                    "count": [
                       {
-                        "geq": [
+                        "select": [
                           {
-                            "map": [
+                            "geq": [
                               "_transportPayloadLength",
-                              "forward"
+                              1300
                             ]
-                          },
-                          1300
+                          }
                         ]
                       }
                     ]
-                  }
+                  },
+                  "packetTotalCount"
                 ]
               },
-              {
-                "map": [
-                  "packetTotalCount",
-                  "forward"
-                ]
-              }
+              "forward"
             ]
           },
           {
@@ -453,31 +433,31 @@
             ]
           },
           {
-            "map": [
+            "apply": [
               "tcpPshTotalCount",
               "backward"
             ]
           },
           {
-            "map": [
+            "apply": [
               "tcpAckTotalCount",
               "backward"
             ]
           },
           {
-            "map": [
+            "apply": [
               "tcpPshTotalCount",
               "forward"
             ]
           },
           {
-            "map": [
+            "apply": [
               "tcpAckTotalCount",
               "forward"
             ]
           },
           {
-            "map": [
+            "apply": [
               "tcpPshTotalCount",
               "backward"
             ]
@@ -485,32 +465,27 @@
           {
             "divide": [
               {
-                "count": [
+                "apply": [
                   {
-                    "select": [
+                    "count": [
                       {
-                        "equal": [
+                        "select": [
                           {
-                            "map": [
+                            "equal": [
                               "_transportPayloadLength",
-                              "forward"
+                              0
                             ]
-                          },
-                          0
+                          }
                         ]
                       }
                     ]
-                  }
+                  },
+                  "forward"
                 ]
               },
               {
                 "count": [
-                  {
-                    "map": [
-                      "_transportPayloadLength",
-                      "forward"
-                    ]
-                  }
+                  "forward"
                 ]
               }
             ]
@@ -518,32 +493,27 @@
           {
             "divide": [
               {
-                "count": [
+                "apply": [
                   {
-                    "select": [
+                    "count": [
                       {
-                        "equal": [
+                        "select": [
                           {
-                            "map": [
+                            "equal": [
                               "_transportPayloadLength",
-                              "backward"
+                              0
                             ]
-                          },
-                          0
+                          }
                         ]
                       }
                     ]
-                  }
+                  },
+                  "backward"
                 ]
               },
               {
                 "count": [
-                  {
-                    "map": [
-                      "_transportPayloadLength",
-                      "backward"
-                    ]
-                  }
+                  "backward"
                 ]
               }
             ]
@@ -564,17 +534,19 @@
                   }
                 ]
               },
-              {
-                "count": [
-                  "_transportPayloadLength"
-                ]
-              }
+              "packetTotalCount"
             ]
           }
+        ],
+        "key_features": [
+          "sourceIPv4Address",
+          "sourceTransportPort",
+          "destinationIPv4Address",
+          "destinationTransportPort",
+          "protocolIdentifier"
         ]
       }
     ],
-    "flows": [],
     "flow_aggregations": []
   },
   "analysis_method": {

--- a/v2_papers/2012/jin_modular.json
+++ b/v2_papers/2012/jin_modular.json
@@ -159,17 +159,13 @@
             ]
           },
           {
-            "count": [
+            "distinct": [
               {
-                "distinct": [
+                "map": [
+                  "ipClassOfService",
                   {
-                    "map": [
-                      "ipClassOfService",
-                      {
-                        "select": [
-                          true
-                        ]
-                      }
+                    "select": [
+                      true
                     ]
                   }
                 ]

--- a/v2_papers/2012/zhang_unsupervised.json
+++ b/v2_papers/2012/zhang_unsupervised.json
@@ -61,25 +61,25 @@
         "bidirectional": false,
         "features": [
           {
-            "map": [
+            "apply": [
               "packetTotalCount",
               "forward"
             ]
           },
           {
-            "map": [
+            "apply": [
               "octetTotalCount",
               "forward"
             ]
           },
           {
-            "map": [
+            "apply": [
               "minimumIpTotalLength",
               "forward"
             ]
           },
           {
-            "map": [
+            "apply": [
               "maximumIpTotalLength",
               "forward"
             ]
@@ -145,25 +145,25 @@
             ]
           },
           {
-            "map": [
+            "apply": [
               "packetTotalCount",
               "backward"
             ]
           },
           {
-            "map": [
+            "apply": [
               "octetTotalCount",
               "backward"
             ]
           },
           {
-            "map": [
+            "apply": [
               "minimumIpTotalLength",
               "backward"
             ]
           },
           {
-            "map": [
+            "apply": [
               "maximumIpTotalLength",
               "backward"
             ]
@@ -226,13 +226,6 @@
                   "backward"
                 ]
               }
-            ]
-          },
-          {
-            "slice": [
-              0,
-              512,
-              "__flowPayload"
             ]
           }
         ],

--- a/v2_papers/2016/iglesias_time-activity.json
+++ b/v2_papers/2016/iglesias_time-activity.json
@@ -135,7 +135,7 @@
               "_interPacketTimeMicroseconds"
             ]
           },
-          "__numberof_activity_intervals"
+          "__numberOfActivityIntervals"
         ],
         "key_features": [
           "sourceIPv4Address",

--- a/v2_papers/2017/iglesias_pattern-discovery.json
+++ b/v2_papers/2017/iglesias_pattern-discovery.json
@@ -97,7 +97,7 @@
         "bidirectional": false,
         "features": [
           {
-            "count": [
+            "distinct": [
               "destinationIPv4Address"
             ]
           },
@@ -125,7 +125,7 @@
             ]
           },
           {
-            "count": [
+            "distinct": [
               "sourceTransportPort"
             ]
           },
@@ -153,7 +153,7 @@
             ]
           },
           {
-            "count": [
+            "distinct": [
               "destinationTransportPort"
             ]
           },
@@ -181,7 +181,7 @@
             ]
           },
           {
-            "count": [
+            "distinct": [
               "protocolIdentifier"
             ]
           },
@@ -209,7 +209,7 @@
             ]
           },
           {
-            "count": [
+            "distinct": [
               "ipTTL"
             ]
           },
@@ -237,7 +237,7 @@
             ]
           },
           {
-            "count": [
+            "distinct": [
               "tcpControlBits"
             ]
           },
@@ -265,7 +265,7 @@
             ]
           },
           {
-            "count": [
+            "distinct": [
               "ipTotalLength"
             ]
           },


### PR DESCRIPTION
Fixed some features that were spotted with a more thorough implementation of the verifier.

@muxamilian please check in particular:
- [x] `2012/bujlow_amethod.json`:
  * changed packet to flow (had a quick glance at the paper, seems to use flows)
  * changed many of the features that use map, to be consistent with the specification
- [x] `2012/zhang_unsupervised.json`:
  * switched some `map` to `apply`
  * removed the features that uses the payload; from what I understand they use a flow vector without payload, and in a second step use a separate bag of words vector generated from the payload; so in a way I think it should have 2 different flows, but on the other hand we have no way to represent bag of words, so I just removed it
- [x] `2008/zhao_realtime.json`:
  * changed packet to flow (had a quick glance at the paper, seems to use flows, even if incomplete)

The remaining papers that were modified were very small changes.

@notti can you also fix your `2008/yang_ap2pnetwork.json` and `2007/auld_bayesian.json` and commit them to this PR?

New verifier will be updated soon :)