### PR TITLE
Fix flow key in 2016/iglesias_time-activity

### DIFF
--- a/v2_papers/2016/iglesias_time-activity.json
+++ b/v2_papers/2016/iglesias_time-activity.json
@@ -138,9 +138,9 @@
           "__numberOfActivityIntervals"
         ],
         "key_features": [
+          "__60SecondTimeWindowID",
           "sourceIPv4Address",
-          "destinationIPv4Address",
-          "protocolIdentifier"
+          "destinationIPv4Address"
         ]
       },
       {
@@ -178,12 +178,14 @@
           }
         ],
         "key_features": [
+          "__60SecondTimeWindowID",
           "sourceIPv4Address",
-          "destinationIPv4Address",
-          "protocolIdentifier"
+          "destinationIPv4Address"
         ]
       }
-    ]
+    ],
+    "packets": "none",
+    "flow_aggregations": "none"
   },
   "analysis_method": {
     "supervised_learning": false,

--- a/v2_papers/2016/iglesias_time-activity.json
+++ b/v2_papers/2016/iglesias_time-activity.json
@@ -21,8 +21,8 @@
     },
     "access_open": false,
     "curated_by": "fiv",
-    "curated_last_revision": "12-11-2018",
-    "curated_revision_number": 5
+    "curated_last_revision": "28-11-2018",
+    "curated_revision_number": 6
   },
   "data": {
     "datasets": [


### PR DESCRIPTION
Flow key is actually timewindowid, srcaddress, dstaddress.
If packets belonging to different protocols are encountered, the
protocol is set to -1